### PR TITLE
Fix navigation elements for a11y

### DIFF
--- a/base/templates/base/includes/footer.html
+++ b/base/templates/base/includes/footer.html
@@ -18,21 +18,18 @@
        
             <div class="col my-3 order-md-last">
                 <h2 class="h5">Research Data</h2>
-                {% if site_root.get_children.live.in_menu %}
-                    <ul class="nav flex-column" role="navigation">
-                        {% for menuitem in site_root.get_children.live.in_menu %}
-                            <li class="nav-item mb-2"><a class="nav-link p-0" href="{% pageurl menuitem %}">{{ menuitem.title }}</a></li>
-                        {% endfor %}
-                    </ul>
-                {% endif %}
+                <p class="text-muted">Your gateway to research data management and resources at the University of Chicago.</p>
             </div>    
 
             <div class="col my-3">
-                <ul class="nav flex-column">
-                    <li class="nav-item mb-2"><a class="nav-link p-0" href="/privacy-policy">Privacy Policy</a></li>
-                    <li class="nav-item mb-2"><a class="nav-link p-0" href="/contact-us">Contact Us</a></li>
-                    <li class="nav-item mb-2"><a class="nav-link p-0" href="/admin">Staff Login</a></li>
-                </ul>
+                <h3 class="h6">Quick Links</h3>
+                <nav aria-label="Footer navigation">
+                    <ul class="nav flex-column">
+                        <li class="nav-item mb-2"><a class="nav-link p-0" href="/privacy-policy">Privacy Policy</a></li>
+                        <li class="nav-item mb-2"><a class="nav-link p-0" href="/contact-us">Contact Us</a></li>
+                        <li class="nav-item mb-2"><a class="nav-link p-0" href="/admin">Staff Login</a></li>
+                    </ul>
+                </nav>
             </div>
 
         </div>

--- a/base/templates/base/includes/header.html
+++ b/base/templates/base/includes/header.html
@@ -2,7 +2,7 @@
 
 <header>
     {% get_site_root as site_root %}
-    <nav class="navbar nav-underline navbar-expand-md bg-primary" data-bs-theme="dark">
+    <nav class="navbar nav-underline navbar-expand-md bg-primary" data-bs-theme="dark" aria-label="Main navigation">
         <div class="container-sm">
             {% with main_logo_link=settings.base.MainLogo.link main_logo_img=settings.base.MainLogo.image %}
                 {% if main_logo_link and main_logo_img %}


### PR DESCRIPTION
Fixes #40 

- wraps navigation lists in <nav> elements to be semantically correct.
- removes redundant navigation from footer to improve accessibility.